### PR TITLE
Fixes issue with using advanced yara rules and upgrades Dockers

### DIFF
--- a/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python-pip
+RUN apt-get install -y --fix-missing python-pip build-essential
 RUN pip install tornado pefile bitstring
 
 # add the files to the container

--- a/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y --fix-missing python-pip build-essential
+RUN apt-get install -y --fix-missing python-pip build-essential python-dev
 RUN pip install tornado pefile bitstring
 
 # add the files to the container

--- a/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev
+RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev
 
 
 # install python3 dependencies

--- a/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update 
-# && apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev
 
 
@@ -17,7 +16,7 @@ RUN wget https://github.com/plusvic/yara/archive/v3.4.0.tar.gz
 RUN tar -zxf v3.4.0.tar.gz
 WORKDIR /yara/yara-3.4.0
 RUN ./bootstrap.sh
-RUN ./configure --with-crypto
+RUN ./configure --with-crypto --enable-magic
 RUN make
 RUN make install
 
@@ -43,7 +42,7 @@ ADD yara_worker.py /service
 # gather the rules and add them
 ADD rules.yar /service
 WORKDIR /service
-RUN ["python3", "getrules.py"]
+RUN python3 getrules.py
 
 
 # create a new user with limited access

--- a/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev
+RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev
 
 
 # install python3 dependencies

--- a/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
+++ b/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
@@ -27,7 +27,7 @@ class YaraHandler(tornado.web.RequestHandler):
 		return yara.load(sys.argv[1])
 
 class YaraProcess(YaraHandler):
-	def process(self, tup, rules=None):
+	def process(self, filename, rules=None):
 		try:
 			if rules:
 				ruleBuff = StringIO()
@@ -35,9 +35,9 @@ class YaraProcess(YaraHandler):
 				ruleBuff.seek(0)
 
 				rules = yara.load(file=ruleBuff)
-				results = rules.match(tup)
+				results = rules.match(filename[0], external={'filename': filename[1]})
 			else:
-				results = self.YaraEngine.match(tup)
+				results = self.YaraEngine.match(filename[0], external=external={'filename': filename[1]})
 			results2 = list(map(lambda x: {"rules": x.rules}, results))
 			return results2
 		except Exception as e:
@@ -46,7 +46,7 @@ class YaraProcess(YaraHandler):
 	def get(self, filename):
 		print("get req")
 		try:
-			fullPath = os.path.join('/tmp/', filename)
+			fullPath = (os.path.join('/tmp/', filename), filename)
 			data = self.process(fullPath)
 			print(data)
 			self.write({"yara": data})

--- a/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
+++ b/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
@@ -37,7 +37,7 @@ class YaraProcess(YaraHandler):
 				rules = yara.load(file=ruleBuff)
 				results = rules.match(filename[0], external={'filename': filename[1]})
 			else:
-				results = self.YaraEngine.match(filename[0], external=external={'filename': filename[1]})
+				results = self.YaraEngine.match(filename[0], external={'filename': filename[1]})
 			results2 = list(map(lambda x: {"rules": x.rules}, results))
 			return results2
 		except Exception as e:

--- a/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
+++ b/src/main/scala/org/novetta/zoo/services/yara/yara_worker.py
@@ -35,10 +35,10 @@ class YaraProcess(YaraHandler):
 				ruleBuff.seek(0)
 
 				rules = yara.load(file=ruleBuff)
-				results = rules.match(filename[0], external={'filename': filename[1]})
+				results = rules.match(filename[0], externals={'filename': filename[1]})
 			else:
-				results = self.YaraEngine.match(filename[0], external={'filename': filename[1]})
-			results2 = list(map(lambda x: {"rules": x.rules}, results))
+				results = self.YaraEngine.match(filename[0], externals={'filename': filename[1]})
+			results2 = list(map(lambda x: {"rules": x.rule}, results))
 			return results2
 		except Exception as e:
 			return e

--- a/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y python-pip
+RUN apt-get install -y --fix-missing python-pip build-essential
 RUN pip install tornado
 
 # add the files to the container
@@ -18,4 +18,4 @@ RUN chown -R service /service
 USER service
 WORKDIR /service
 
-CMD python2 /service/zipmeta.py
+CMD ["python2", "/service/zipmeta.py"]

--- a/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 
 # install what you need here
 RUN apt-get update && apt-get -y upgrade
-RUN apt-get install -y --fix-missing python-pip build-essential
+RUN apt-get install -y --fix-missing python-pip build-essential python-dev
 RUN pip install tornado
 
 # add the files to the container


### PR DESCRIPTION
This pull request fixes the issue with using advanced yara rules. Specifically:
1) the system now support magic based rules
2) the system uses the files externals flag which supports many public rules. Currently this is just a hash but in the future we can start to pass in the original filename

The pull also upgrades the dockers to use tornado's c extensions. This will close #56.
