### PR TITLE
Removed git upgrade from docker files

### DIFF
--- a/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/peinfo/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update
 RUN apt-get install -y --fix-missing python-pip build-essential python-dev
 RUN pip install tornado pefile bitstring
 

--- a/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/yara/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update
 RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev
 
 

--- a/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update
 RUN apt-get install -y --fix-missing python-pip build-essential python-dev
 RUN pip install tornado
 


### PR DESCRIPTION
This process was taking a long time and really didn't add much benefit. For now, I think it is safe to remove the feature.
