### PR TITLE
added tags to totem

### DIFF
--- a/src/main/scala/org/novetta/zoo/actors/RabbitConsumerActor.scala
+++ b/src/main/scala/org/novetta/zoo/actors/RabbitConsumerActor.scala
@@ -128,13 +128,14 @@ class RabbitConsumerActor[T: Manifest](host: HostSettings, exchange: ExchangeSet
     case RabbitMessage(deliveryTag: Long, body: Array[Byte]) =>
         try {
           parse(new String(body)).extract[T] match {
-            case ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], attempts: Int) =>
+            case ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], tags: List[String], attempts: Int) =>
               log.info("Created a ZooWork, {}", filename)
               val uuid_filename: String = UUID.randomUUID().toString
               WorkGroupActor ! Create(
                 deliveryTag,
                 primaryURI,
                 secondaryURI,
+                tags,
                 WorkState.create(
                   uuid_filename,
                   filename,

--- a/src/main/scala/org/novetta/zoo/actors/RabbitProducerActor.scala
+++ b/src/main/scala/org/novetta/zoo/actors/RabbitProducerActor.scala
@@ -118,12 +118,13 @@ class RabbitProducerActor(host: HostSettings, exchange: ExchangeSettings, result
       val j = compact(render(json))
       sendMessage(RMQSendMessage(j.getBytes, r.result.routingKey))
 
-    case ResultPackage(filename: String, results: Iterable[WorkResult], md5: String, sha1: String, sha256: String) => //work can get lost here. Need to make sure that doesnt happen.
+    case ResultPackage(filename: String, results: Iterable[WorkResult], tags: List[String], md5: String, sha1: String, sha256: String) => //work can get lost here. Need to make sure that doesnt happen.
       results.foreach({ result =>
 
         val json = (
           ("filename" -> filename) ~
             ("data" -> result.data) ~
+            ("tags" -> tags) ~
             ("md5" -> md5) ~
             ("sha1" -> sha1) ~
             ("sha256" -> sha256)
@@ -134,7 +135,7 @@ class RabbitProducerActor(host: HostSettings, exchange: ExchangeSettings, result
       sender ! ResultResolution(true)
       log.info("emitting result {} to RMQ", sender().path)
 
-    case ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], attempts: Int) =>
+    case ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], tags: List[String], attempts: Int) =>
       val incremented_attempts = attempts + 1
       val json = (
         ("primaryURI" -> primaryURI) ~

--- a/src/main/scala/org/novetta/zoo/actors/WorkGroup.scala
+++ b/src/main/scala/org/novetta/zoo/actors/WorkGroup.scala
@@ -47,12 +47,12 @@ object WorkGroup {
 class WorkGroup extends Actor with ActorLogging with MonitoredActor {
 
   def monitoredReceive = {
-    case Create(key: Long, primaryURI: String, secondaryURI: String, value: WorkState, config: DownloadSettings) =>
+    case Create(key: Long, primaryURI: String, secondaryURI: String, tags: List[String], value: WorkState, config: DownloadSettings) =>
       val child = context.child(key.toString).getOrElse({
         log.info("Instantiating a new actor for message: {}", key)
         context.watch(
           context.actorOf(
-            WorkActor.props(key, value.filename, value.hashfilename, primaryURI,secondaryURI, value.workToDo, value.attempts, config), key.toString
+            WorkActor.props(key, value.filename, value.hashfilename, primaryURI,secondaryURI, value.workToDo, tags, value.attempts, config), key.toString
           )
         )
 

--- a/src/main/scala/org/novetta/zoo/types/CommandTypes.scala
+++ b/src/main/scala/org/novetta/zoo/types/CommandTypes.scala
@@ -13,7 +13,7 @@ import org.novetta.zoo.util.DownloadSettings
  * @constructor Generate a Create message. This is used to initiate the creation of a WorkActor
  *
  */
-case class Create(key: Long, primaryURI: String, secondaryURI: String, value: WorkState, config: DownloadSettings)
+case class Create(key: Long, primaryURI: String, secondaryURI: String, tags: List[String], value: WorkState, config: DownloadSettings)
 
 /**
  * Result case class. Used between the WorkActor and the ProducerActor
@@ -30,6 +30,7 @@ case class Result(filename: String, result: WorkResult)
  * the target processing file, that information is lost due to the UUID usage in the temporary filestore.
  * @param filename: String => The filename representing the target of this Job
  * @param results: Iterable[WorkResult] => An Iterable representing the WorkResults to be transmitted
+ * @param tags: List[String] => A list of tags for the results
  * @param MD5: String => MD5 hash of the target file.
  * @param SHA1: String => SHA1 hash of the target file.
  * @param SHA256: String => SHA256 hash of the target file.
@@ -37,7 +38,7 @@ case class Result(filename: String, result: WorkResult)
  * @constructor Generate a ResultPackage message. This is for multiple WorkResult transfers.
  *
  */
-case class ResultPackage(filename: String, results: Iterable[WorkResult], MD5: String, SHA1: String, SHA256: String)
+case class ResultPackage(filename: String, results: Iterable[WorkResult], tags: List[String], MD5: String, SHA1: String, SHA256: String)
 
 object WorkState {
   def create(filename: String, hashfilename: String, workToDo: List[TaskedWork], results: List[WorkResult] = List[WorkResult](), attempts: Int): WorkState = {

--- a/src/main/scala/org/novetta/zoo/types/RMQM.scala
+++ b/src/main/scala/org/novetta/zoo/types/RMQM.scala
@@ -4,7 +4,7 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods._
 
 
-case class ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], attempts: Int) {
+case class ZooWork(primaryURI: String, secondaryURI: String, filename: String, tasks: Map[String, List[String]], tags: List[String], attempts: Int) {
 
   def +(that: WorkFailure): ZooWork = {
     val newtasks = this.tasks + (that.WorkType -> that.Arguments)
@@ -13,6 +13,7 @@ case class ZooWork(primaryURI: String, secondaryURI: String, filename: String, t
       secondaryURI = this.secondaryURI,
       filename = this.filename,
       tasks = newtasks,
+      tags = this.tags,
       attempts = this.attempts
     )
   }


### PR DESCRIPTION
Added tags to totem, this means that you can add tags to an incoming AMQP message in the style of:

``` json
{
   "primaryURI":"http://localhost/file",
   "secondaryURI":"http://localhost/file",
   "filename":"file",
   "tasks":{
      "YARA":[]
   },
   "tags":[
      "tag1",
      "tag2",
      "debugging"
   ],
   "attempts":0
}
```

These tags will then be passed along and added to the result so the storage engine can add them to the result document or use them otherwise. For more Information see HolmesProcessing/Holmes-Storage#2.

This does not break backwards compatibility since incoming messages without a `tags` field will default to an empty list.
