### PR TITLE
Bugfix for zipmeta

### DIFF
--- a/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
+++ b/src/main/scala/org/novetta/zoo/services/zipmeta/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /service/library
 # to overcome the caching issue, the correct revision must go here
 RUN git fetch origin && git checkout 481280325e5e65ca6b83337f678537f22be834cc
 
-ADD LICENSE README.md service.meta /service/
+ADD LICENSE README.md service.conf /service/
 ADD zipmeta.py ZipParser.py extra_field_parse.py /service/
 
 # create a new user with limited access


### PR DESCRIPTION
service.meta files had been dropped in favor of a unified service.conf
Dockerfile wasn't updated to reflect this change
