### PR TITLE
Merged "apt-get update" and "apt-get install" lines in Dockerfiles to prevent caching issues

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/services/asnmeta/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/asnmeta/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --fix-missing python3-pip
+RUN apt-get update && apt-get install -y --fix-missing python3-pip
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/asnmeta/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/asnmeta/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --fix-missing python3-pip
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --fix-missing python3-pip
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/dnsmeta/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/dnsmeta/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --fix-missing python3-pip
+RUN apt-get update && apt-get install -y --fix-missing python3-pip
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/dnsmeta/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/dnsmeta/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y --fix-missing python3-pip
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --fix-missing python3-pip
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/objdump/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/objdump/Dockerfile
@@ -1,8 +1,7 @@
 FROM golang:1.6.2
 
 # Install objdump if not yet installed.
-RUN apt-get update
-RUN apt-get install -y --force-yes --fix-missing binutils
+RUN apt-get update && apt-get install -y --force-yes --fix-missing binutils
 
 # Add relevant files to the container.
 RUN mkdir -p /service

--- a/src/main/scala/org/holmesprocessing/totem/services/peid/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/peid/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update
-RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev git
+RUN apt-get update && apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev git
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/peinfo/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/peinfo/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update
-RUN apt-get install -y --fix-missing python-pip build-essential python-dev git
+RUN apt-get update && apt-get install -y --fix-missing python-pip build-essential python-dev git
 RUN pip install tornado pefile bitstring
 
 # get holmeslibrary

--- a/src/main/scala/org/holmesprocessing/totem/services/yara/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/yara/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update
-RUN apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev git
+RUN apt-get update && apt-get install -y --fix-missing python3-pip wget build-essential checkinstall dh-autoreconf libssl-dev libmagic-dev python-dev git
 
 
 # install python3 dependencies

--- a/src/main/scala/org/holmesprocessing/totem/services/zipmeta/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/zipmeta/Dockerfile
@@ -1,8 +1,7 @@
 FROM ubuntu:14.04
 
 # install what you need here
-RUN apt-get update
-RUN apt-get install -y --fix-missing python-pip build-essential python-dev git
+RUN apt-get update && apt-get install -y --fix-missing python-pip build-essential python-dev git
 RUN pip install tornado
 
 # add the files to the container


### PR DESCRIPTION
Docker caches the images after each command. In this case, this can lead to caching issues, if Docker uses a cache from just between the "apt-get update"- and the "apt-get install"-line, since it might happen, that the package versions in apt's database from the cached image aren't available on the ubuntu-servers anymore.

This fix ensures, that the package-versions are always updated, just before they are installed.
