### PR TITLE
Objdump service: Patch for uniform logging.

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/services/objdump/objdump.go
+++ b/src/main/scala/org/holmesprocessing/totem/services/objdump/objdump.go
@@ -69,7 +69,7 @@ type Config struct {
 // global variables
 var (
     config                  Config  // = &Config{}
-    info                    *log.Logger
+    infoLogger              *log.Logger
     objdump_binary_path     string
 )
 
@@ -80,58 +80,58 @@ func main () {
         // err error
         configPath string
     )
-    
+
     // setup logging
-    info = log.New(os.Stdout, "", log.Ltime|log.Lshortfile)
-    
+    infoLogger = log.New(os.Stdout, "", log.Ltime|log.Lshortfile)
+
     // load config
     flag.StringVar(&configPath, "config", "", "Path to the configuration file")
     flag.Parse()
-    
+
     if configPath == "" {
         configPath, _ = filepath.Abs(filepath.Dir(os.Args[0]))
         configPath += "/service.conf"
     }
-    
+
     config = load_config(configPath)
-    
+
     // find objdump binary path
     if binary, err := exec.LookPath("objdump"); err != nil {
-        log.Fatalln("Unable to locate objdump binary, is objdump installed?", err)
+        infoLogger.Fatalln("Unable to locate objdump binary, is objdump installed?", err)
     } else {
         objdump_binary_path = binary
     }
-    
+
     // setup http handlers
     router := httprouter.New()
     router.GET("/objdump/:file", handler_analyze)
     router.GET("/", handler_info)
-    
+
     port := config.Settings.Port
     address := fmt.Sprintf(":%s",port)
-    
-    log.Printf("Binding to %s\n", address)
-    log.Fatal(http.ListenAndServe(address, router))
+
+    infoLogger.Printf("Binding to %s\n", address)
+    infoLogger.Fatal(http.ListenAndServe(address, router))
 }
 
 
 // Parse a configuration file into a configuration structure.
 func load_config (configPath string) Config {
-    
+
     // Create a new config object. Initialize it empty for now.
     config := Config{Metadata: Metadata{}, Settings: Settings{}}
-    
+
     // Prepare reflection to be able to set values later.
     r_metadata := reflect.ValueOf(&(config.Metadata)).Elem()
     r_settings := reflect.ValueOf(&(config.Settings)).Elem()
-    
+
     // Attempt to read the INI-File. If it fails to open and read from the file,
     // throw a fatal error and exit.
     inifile, err := ini.Load(configPath)
     if err != nil {
-        log.Fatalf("Unable to read config file %s", configPath)
+        infoLogger.Fatalf("Unable to read config file %s", configPath)
     }
-    
+
     // Get a list of all section names in the INI-File and iterate over them.
     // Convert each name to lower case and check if it corresponds to one of our
     // sections. If this is the case, set the respective mapping so we can find
@@ -140,19 +140,19 @@ func load_config (configPath string) Config {
     for _, section_name := range inifile.SectionStrings() {
         lower_case := strings.ToLower(section_name)
         if lower_case == "metadata" || lower_case == "settings" {
-            log.Printf("Found section %s (%s)\n", lower_case, section_name)
+            infoLogger.Printf("Found section %s (%s)\n", lower_case, section_name)
             sections[lower_case] = section_name
         }
     }
-    
+
     // If one of our required sections isn't supplied, error out.
     if _, exists := sections["metadata"]; !exists {
-        log.Fatalln("Fatal Error: Unable to find a metadata section in the supplied config")
+        infoLogger.Fatalln("Fatal Error: Unable to find a metadata section in the supplied config")
     }
     if _, exists := sections["settings"]; !exists {
-        log.Fatalln("Fatal Error: Unable to find a settings section in the supplied config")
+        infoLogger.Fatalln("Fatal Error: Unable to find a settings section in the supplied config")
     }
-    
+
     // Iterate through the two sections and then over all relevant keys.
     // Using a lot of helper structures here, looks ugly, but effectively makes
     // this a bit more efficient and allows using the same code for all sections
@@ -168,7 +168,7 @@ func load_config (configPath string) Config {
     ini_keys  := make(map[string][]string)
     ini_keys["metadata"] = []string{"Name", "Version", "Description", "Copyright", "License"}
     ini_keys["settings"] = []string{"Port", "InfoURL", "AnalysisURL", "MaxNumberOfOpcodes"}
-    
+
     for _, section_name := range section_list {
         // Per section we require a ini_map section, create it.
         // it consists of a Mapping struct reference containing information
@@ -205,7 +205,7 @@ func load_config (configPath string) Config {
         // or license load the file contents instead if the file is available.
         for _, mapping := range ini_map[section_name] {
             if !mapping.exists {
-                log.Fatalf("Fatal Error: Missing key %s in the %s config\n", mapping.key, section_name)
+                infoLogger.Fatalf("Fatal Error: Missing key %s in the %s config\n", mapping.key, section_name)
             }
             if section_name == "metadata" {
                 if mapping.key_lower == "description" || mapping.key_lower == "license" {
@@ -219,7 +219,7 @@ func load_config (configPath string) Config {
             }
         }
     }
-    
+
     return config
 }
 
@@ -239,30 +239,30 @@ func handler_info(f_response http.ResponseWriter, r *http.Request, ps httprouter
 
 
 func handler_analyze (f_response http.ResponseWriter, request *http.Request, params httprouter.Params) {
-    log.Println("Serving request:", request)
+    infoLogger.Println("Serving request:", request)
     start_time := time.Now()
-    
+
     sample_path := "/tmp/" + params.ByName("file")
     if _, err := os.Stat(sample_path); os.IsNotExist(err) {
         http.NotFound(f_response, request)
-        log.Printf("Error accessing sample (file: %s):", sample_path)
-        log.Println(err)
+        infoLogger.Printf("Error accessing sample (file: %s):", sample_path)
+        infoLogger.Println(err)
         return
     }
-    
+
     // Run objdump
     // -d: disassemble
     // -w: wide output (not delimited to 80 chars)
     objdump     := exec.Command(objdump_binary_path, "-w", "-d", sample_path)
     stdout, err := objdump.Output()
-    
+
     if err != nil {
         http.Error(f_response, "Executing objdump failed", 500)
-        log.Printf("Error executing objdump (file: %s):", sample_path)
-        log.Println(err)
+        infoLogger.Printf("Error executing objdump (file: %s):", sample_path)
+        infoLogger.Println(err)
         return
     }
-    
+
     // Prepare helper variables and regular expressions.
     // Allocate one big opcode array, for blocks only save slices - way more
     // efficient, no copy actions.
@@ -287,7 +287,7 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
         Blocks  []*Block        `json:"blocks"`
     }
     map_sections := make(map[string]*Section)
-    
+
     var (
         line            string
         line_offset     int
@@ -300,16 +300,16 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
         cur_block       *Block
         processed       bool
     )
-    
+
     opcodes_max, _   = strconv.ParseInt(config.Settings.MaxNumberOfOpcodes, 10, 64)
     opcodes         := make([]string, opcodes_max)
-    
+
     expect_format   := 0x1
     expect_section  := 0x2
     expect_block    := 0x4
     expect_opcode   := 0x8
     expected        := expect_format
-    
+
     re_fileformat   := regexp.MustCompile("file format ([^ ]*)") // 1 format
     re_section      := regexp.MustCompile("^Disassembly of section ([^ :]*)") // 1 name
     re_block        := regexp.MustCompile("^0*([0-9a-f]+)( <([^>]+)>)?:") // 1 off, 3 name
@@ -317,17 +317,17 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
     // re_opcode       := regexp.MustCompile("^  0*([0-9a-f]+):\\t[^\\t]+\\t(.*)") // 1 off, 2 op
     re_opcode       := regexp.MustCompile("^  0*([0-9a-f]+):\\t[^\\t]+\\t([^ ]*)") // 1 off, 2 op
     re_ellipsis     := regexp.MustCompile("^[ \\t]+\\.\\.\\.$")
-    
+
     opcodes_total = 0
     opcodes_index = 0
-    
+
     line, line_offset, line_more = nextline(stdout, 0)
     for line_more {
-        
+
         // fmt.Fprint(f_response, line+"\n")
-        
+
         processed = false
-        
+
         // This is the most likely case, as there should be much more opcodes
         // than blocks or sections. As such this should be checked for first.
         if (expected & expect_opcode) != 0 {
@@ -346,14 +346,14 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
                 processed = true
             }
         }
-        
+
         // Tackle ellipsis (consecutive nullbytes).
         if !processed && (expected & expect_opcode) != 0 {
             if result := re_ellipsis.FindStringSubmatch(line); len(result)>0 {
                 processed = true
             }
         }
-        
+
         // The second most likely occurence is that we have a block (each
         // section may have multiple blocks).
         if !processed && (expected & expect_block) != 0 {
@@ -376,7 +376,7 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
                 processed = true
             }
         }
-        
+
         // Then we have the sections, which we should have a couple in each
         // binary. Next to the file format this is the least likely to be hit.
         // Whilst there is only one file format there may be quite a bunch of
@@ -384,7 +384,7 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
         if !processed && (expected & expect_section) != 0 {
             if result := re_section.FindStringSubmatch(line); len(result)>0 {
                 if _, exists := map_sections[result[1]]; exists {
-                    log.Printf("Error: Found duplicate section %s, ignoring.\n", result[1])
+                    infoLogger.Printf("Error: Found duplicate section %s, ignoring.\n", result[1])
                 } else {
                     cur_section = &Section{Name: result[1]}
                     map_sections[result[1]] = cur_section
@@ -393,7 +393,7 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
                 processed = true
             }
         }
-        
+
         // This should only happen once and only at the start of the input.
         // As such this comparison is last.
         if !processed && (expected & expect_format) != 0 {
@@ -403,28 +403,28 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
                 processed = true
             } else {
                 http.Error(f_response, "Unable to determine file format", 500)
-                log.Println("Fatal Error: Unable to determine file format.")
+                infoLogger.Println("Fatal Error: Unable to determine file format.")
                 return
             }
         }
-        
+
         // Catch unprocessed error
         if !processed {
             http.Error(f_response, fmt.Sprintf("Unexpected output '%s'", line), 500)
-            log.Printf("Fatal Error: Unable to process unexpected output '% x'.\n", line, expected)
+            infoLogger.Printf("Fatal Error: Unable to process unexpected output '% x'.\n", line, expected)
             return
         }
-        
+
         // Get the next line.
         line, line_offset, line_more = nextline(stdout, line_offset)
     }
-    
+
     // check if we have truncated the output
     truncated := false
     if opcodes_total >= opcodes_max && line_more {
         truncated = true
     }
-    
+
     // After all data is parsed, assemble json
     type AnalysisResult struct {
         Fileformat string               `json:"fileformat"`
@@ -438,13 +438,13 @@ func handler_analyze (f_response http.ResponseWriter, request *http.Request, par
     analysis_result.Truncated  = truncated
     analysis_result.Sections   = map_sections
     analysis_result_json, err := json.Marshal(analysis_result)
-    
+
     // fmt.Println(string(analysis_result_json))
     f_response.Header().Set("Content-Type","text/json; charset=utf-8")
     fmt.Fprint(f_response, string(analysis_result_json))
-    
+
     elapsed_time := time.Since(start_time)
-    log.Printf("Done, read a total of %d opcodes in %s.\n", opcodes_total, elapsed_time)
+    infoLogger.Printf("Done, read a total of %d opcodes in %s.\n", opcodes_total, elapsed_time)
 }
 
 
@@ -460,16 +460,16 @@ func nextline (s []byte, offset int) (string, int, bool) {
         b byte
         size int
     )
-    
+
     i = 0
     size = len(s)
-    
+
     for i < 0x1000 && offset+i < size {
         b = s[offset+i]
-        
+
         nextline_buffer[i] = b
         i = i+1
-        
+
         if b == '\n' {
             // ignore empty lines
             if i==1 {
@@ -480,14 +480,14 @@ func nextline (s []byte, offset int) (string, int, bool) {
             break
         }
     }
-    
+
     interims := nextline_buffer[0:i]
     if interims[i-1] == '\n' {
         interims = interims[0:i-1]
     }
-    
+
     result := string(interims)
-    
+
     if offset+i < size {
         return result, offset+i, true
     } else {


### PR DESCRIPTION
A logger instance was created but not used. Renamed the logger instance and replaced all log statements with the logger instance.
