### PR TITLE
VirusTotal service patch

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/services/virustotal/service.conf.example
+++ b/src/main/scala/org/holmesprocessing/totem/services/virustotal/service.conf.example
@@ -11,6 +11,7 @@
 		"InfoURL": "/",
 		"AnalysisURL": "/gogadget",
 		"ApiKey": "PutYourKeyHere",
-		"UploadUnknownSamples": false
+		"UploadUnknownSamples": false,
+		"RequestTimeout": 60
 	}
 }


### PR DESCRIPTION
- Added RequestTimeout setting (otherwise unlimited, worst case piling up requests, see: https://golang.org/pkg/net/http/#Client)
- Uniform logger usage
