### PR TITLE
Enables config items for taskings and rabbit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "totem"
 
-version := "1.0"
+version := "0.5.0"
 
 scalaVersion := "2.11.4" //was 2.10.3
 

--- a/config/totem.conf.example
+++ b/config/totem.conf.example
@@ -1,15 +1,22 @@
 totem {
-  version = "1.0.0"
-  requeueKey = "requeue.static.totem"
-  misbehaveKey = "misbehave.static.totem"
+  version = "0.5.0"
 
   download_settings {
-    download_directory = "/tmp/"
-    request_timeout = 500
+    connection_pooling = true
     connection_timeout = 500
+    download_directory = "/tmp/"
+    thread_multiplier = 4
+    request_timeout = 500
+  }
+
+  tasking_settings {
+    default_service_timeout = 60
+    prefetch = 3
+    retry_attempts = 3
   }
 
   rabbit_settings {
+    requeueKey = "requeue.static.totem"
     host {
       server = "127.0.0.1"
       port = 5672

--- a/src/main/scala/org/holmesprocessing/totem/actors/RabbitProducerActor.scala
+++ b/src/main/scala/org/holmesprocessing/totem/actors/RabbitProducerActor.scala
@@ -152,7 +152,6 @@ class RabbitProducerActor(host: HostSettings, exchange: ExchangeSettings, result
         )
       val j = compact(render(json))
 
-      // TODO: set attempts as a config object
       log.info("RabbitProducer: we have had an error, we have an incremented_attempts of {}", incremented_attempts)
       if(incremented_attempts <= taskingconfig.retry_attempts) {
 

--- a/src/main/scala/org/holmesprocessing/totem/actors/WorkGroup.scala
+++ b/src/main/scala/org/holmesprocessing/totem/actors/WorkGroup.scala
@@ -47,25 +47,22 @@ object WorkGroup {
 class WorkGroup extends Actor with ActorLogging with MonitoredActor {
 
   def monitoredReceive = {
-    case Create(key: Long, download: Boolean, primaryURI: String, secondaryURI: String, tags: List[String], value: WorkState, config: DownloadSettings) =>
+    case Create(key: Long, download: Boolean, primaryURI: String, secondaryURI: String, tags: List[String], value: WorkState, downloadconfig: DownloadSettings) =>
       log.debug("Got a set of work {}", value)
       val child = context.child(key.toString).getOrElse({
         log.info("WorkGroup: instantiating a new actor for message {}", key)
         context.watch(
           context.actorOf(
-            WorkActor.props(key, value.filename, value.hashfilename, download, primaryURI, secondaryURI, value.workToDo, tags, value.attempts, config), key.toString
+            WorkActor.props(key, value.filename, value.hashfilename, download, primaryURI, secondaryURI, value.workToDo, tags, value.attempts, downloadconfig), key.toString
           )
         )
-
       })
     case t: Ack =>
       log.info("WorkGroup: Ack from {}, moving up the chain", sender())
       context.parent.tell(t, sender())
-
     case t: NAck =>
       log.warning("WorkGroup: NAck from {}, moving up the chain", sender())
       context.parent.tell(t, sender())
-
     case Terminated(t: ActorRef) =>
       log.info("WorkGroup: child {} terminated", t)
     case msg =>

--- a/src/main/scala/org/holmesprocessing/totem/driver/driver.scala
+++ b/src/main/scala/org/holmesprocessing/totem/driver/driver.scala
@@ -165,7 +165,7 @@ object driver extends App with Instrumented {
 
   println("Creating Totem Actors")
   val myGetter: ActorRef = system.actorOf(RabbitConsumerActor.props[ZooWork](hostConfig, exchangeConfig, workqueueConfig, encoding, Parsers.parseJ, downloadConfig, taskingConfig).withDispatcher("akka.actor.my-pinned-dispatcher"), "consumer")
-  val mySender: ActorRef = system.actorOf(Props(classOf[RabbitProducerActor], hostConfig, exchangeConfig, resultQueueConfig, misbehaveQueueConfig, encoding, conf.getString("totem.rabbit_settings.requeueKey")), "producer")
+  val mySender: ActorRef = system.actorOf(Props(classOf[RabbitProducerActor], hostConfig, exchangeConfig, resultQueueConfig, misbehaveQueueConfig, encoding, conf.getString("totem.rabbit_settings.requeueKey"), taskingConfig), "producer")
 
   println("Totem version " + conf.getString("totem.version") + " is running and ready to receive tasks")
 

--- a/src/main/scala/org/holmesprocessing/totem/driver/driver.scala
+++ b/src/main/scala/org/holmesprocessing/totem/driver/driver.scala
@@ -39,11 +39,20 @@ object driver extends App with Instrumented {
   }
   val system = ActorSystem("totem")
 
+  println("Configuring details for Totem Tasking")
+  val taskingConfig = TaskingSettings(
+    conf.getInt("totem.tasking_settings.default_service_timeout"),
+    conf.getInt("totem.tasking_settings.prefetch"),
+    conf.getInt("totem.tasking_settings.retry_attempts")
+  )
+
   println("Configuring details for downloading objects")
   val downloadConfig = DownloadSettings(
+    conf.getBoolean("totem.download_settings.connection_pooling"),
+    conf.getInt("totem.download_settings.connection_timeout"),
     conf.getString("totem.download_settings.download_directory"),
-    conf.getInt("totem.download_settings.request_timeout"),
-    conf.getInt("totem.download_settings.connection_timeout")
+    conf.getInt("totem.download_settings.thread_multiplier"),
+    conf.getInt("totem.download_settings.request_timeout")
   )
 
   println("Configuring details for Rabbit queues")
@@ -54,6 +63,7 @@ object driver extends App with Instrumented {
     conf.getString("totem.rabbit_settings.host.password"),
     conf.getString("totem.rabbit_settings.host.vhost")
   )
+
   val exchangeConfig = ExchangeSettings(
     conf.getString("totem.rabbit_settings.exchange.name"),
     conf.getString("totem.rabbit_settings.exchange.type"),
@@ -61,10 +71,9 @@ object driver extends App with Instrumented {
   )
 
   val workqueueKeys = List[String](
-      conf.getString("totem.rabbit_settings.workqueue.routing_key"),
-      conf.getString("totem.requeueKey")
+    conf.getString("totem.rabbit_settings.workqueue.routing_key"),
+    conf.getString("totem.rabbit_settings.requeueKey")
   )
-
   val workqueueConfig = QueueSettings(
     conf.getString("totem.rabbit_settings.workqueue.name"),
     workqueueKeys,
@@ -72,6 +81,7 @@ object driver extends App with Instrumented {
     conf.getBoolean("totem.rabbit_settings.workqueue.exclusive"),
     conf.getBoolean("totem.rabbit_settings.workqueue.autodelete")
   )
+
   val resultQueueConfig = QueueSettings(
     conf.getString("totem.rabbit_settings.resultsqueue.name"),
     List[String](conf.getString("totem.rabbit_settings.resultsqueue.routing_key")),
@@ -108,23 +118,23 @@ object driver extends App with Instrumented {
     def enumerateWork(key: Long, filename: String, workToDo: Map[String, List[String]]): List[TaskedWork] = {
       val w = workToDo.map({
         case ("ASNMETA", li: List[String]) =>
-          ASNMetaWork(key, filename, 60, "ASNMETA", GeneratePartial("ASNMETA"), li)
+          ASNMetaWork(key, filename, taskingConfig.default_service_timeout, "ASNMETA", GeneratePartial("ASNMETA"), li)
         case ("DNSMETA", li: List[String]) =>
-          DNSMetaWork(key, filename, 60, "DNSMETA", GeneratePartial("DNSMETA"), li)
+          DNSMetaWork(key, filename, taskingConfig.default_service_timeout, "DNSMETA", GeneratePartial("DNSMETA"), li)
         case ("GOGADGET", li: List[String]) =>
-          GoGadgetWork(key, filename, 60, "GOGADGET", GeneratePartial("GOGADGET"), li)
+          GoGadgetWork(key, filename, taskingConfig.default_service_timeout, "GOGADGET", GeneratePartial("GOGADGET"), li)
         case ("OBJDUMP", li: List[String]) =>
-          ObjdumpWork(key, filename, 60, "OBJDUMP", GeneratePartial("OBJDUMP"), li)
+          ObjdumpWork(key, filename, taskingConfig.default_service_timeout, "OBJDUMP", GeneratePartial("OBJDUMP"), li)
         case ("PEID", li: List[String]) =>
-          PEiDWork(key, filename, 60, "PEID", GeneratePartial("PEID"), li)
+          PEiDWork(key, filename, taskingConfig.default_service_timeout, "PEID", GeneratePartial("PEID"), li)
         case ("PEINFO", li: List[String]) =>
-          PEInfoWork(key, filename, 60, "PEINFO", GeneratePartial("PEINFO"), li)
+          PEInfoWork(key, filename, taskingConfig.default_service_timeout, "PEINFO", GeneratePartial("PEINFO"), li)
         case ("VIRUSTOTAL", li: List[String]) =>
-          VirustotalWork(key, filename, 60, "VIRUSTOTAL", GeneratePartial("VIRUSTOTAL"), li)
+          VirustotalWork(key, filename, 1800, "VIRUSTOTAL", GeneratePartial("VIRUSTOTAL"), li)
         case ("YARA", li: List[String]) =>
-          YaraWork(key, filename, 60, "YARA", GeneratePartial("YARA"), li)
+          YaraWork(key, filename, taskingConfig.default_service_timeout, "YARA", GeneratePartial("YARA"), li)
         case ("ZIPMETA", li: List[String]) =>
-          ZipMetaWork(key, filename, 60, "ZIPMETA", GeneratePartial("ZIPMETA"), li)
+          ZipMetaWork(key, filename, taskingConfig.default_service_timeout, "ZIPMETA", GeneratePartial("ZIPMETA"), li)
         case (s: String, li: List[String]) =>
           UnsupportedWork(key, filename, 1, s, GeneratePartial(s), li)
         case _ => Unit //need to set this to a non Unit type.
@@ -149,12 +159,13 @@ object driver extends App with Instrumented {
       }
     }
   }
+
   println("Completing configuration")
   val encoding = new TotemicEncoding(conf)
 
   println("Creating Totem Actors")
-  val myGetter: ActorRef = system.actorOf(RabbitConsumerActor.props[ZooWork](hostConfig, exchangeConfig, workqueueConfig, encoding, Parsers.parseJ, downloadConfig).withDispatcher("akka.actor.my-pinned-dispatcher"), "consumer")
-  val mySender: ActorRef = system.actorOf(Props(classOf[RabbitProducerActor], hostConfig, exchangeConfig, resultQueueConfig, misbehaveQueueConfig, encoding, conf.getString("totem.requeueKey")), "producer")
+  val myGetter: ActorRef = system.actorOf(RabbitConsumerActor.props[ZooWork](hostConfig, exchangeConfig, workqueueConfig, encoding, Parsers.parseJ, downloadConfig, taskingConfig).withDispatcher("akka.actor.my-pinned-dispatcher"), "consumer")
+  val mySender: ActorRef = system.actorOf(Props(classOf[RabbitProducerActor], hostConfig, exchangeConfig, resultQueueConfig, misbehaveQueueConfig, encoding, conf.getString("totem.rabbit_settings.requeueKey")), "producer")
 
   println("Totem version " + conf.getString("totem.version") + " is running and ready to receive tasks")
 

--- a/src/main/scala/org/holmesprocessing/totem/types/WorkTypes.scala
+++ b/src/main/scala/org/holmesprocessing/totem/types/WorkTypes.scala
@@ -45,7 +45,6 @@ import scala.util.Random
 //}
 
 trait TaskedWork {
-
   val key: Long
   val filename: String
   val TimeoutMillis: Int
@@ -53,7 +52,6 @@ trait TaskedWork {
   val Worker: String
   val Arguments: List[String]
   def doWork()(implicit myHttp: dispatch.Http): Future[WorkResult]
-
 }
 /**
  * HashWork case class. Holds the tasking and worker path appropriate for this TaskedWork
@@ -113,6 +111,8 @@ abstract class GenericTotemEncoding extends WorkEncoding {
   def workRoutingKey(work: WorkResult): String
 }
 
+// TODO: look at moving some of this to driver.scala
+case class TaskingSettings(default_service_timeout: Int, prefetch: Int, retry_attempts: Int)
 abstract class ConfigTotemEncoding(conf: Config) extends WorkEncoding {
   val keys = conf.getObject("totem.services").keySet()
   val en = conf.getObject("totem.services").toConfig

--- a/src/main/scala/org/holmesprocessing/totem/util/DownloadMethods.scala
+++ b/src/main/scala/org/holmesprocessing/totem/util/DownloadMethods.scala
@@ -5,7 +5,7 @@ import com.typesafe.scalalogging.{Logger, LazyLogging}
 import org.holmesprocessing.totem.types.{WorkState, WorkResult, TaskedWork}
 import org.slf4j.LoggerFactory
 
-case class DownloadSettings(download_directory: String, request_timeout: Int, connect_timeout: Int)
+case class DownloadSettings(connection_pooling: Boolean, connect_timeout: Int, download_directory: String, thread_multiplier: Int, request_timeout: Int)
 
 object DownloadMethods extends Instrumented with LazyLogging {
   val log = Logger(LoggerFactory.getLogger("name"))


### PR DESCRIPTION
Enables config items for taskings: retry attempts, service timeouts, prefetch. Added some rabbit config options as well. 

Also, adjusted version to 0.5.0 as it more accurately reflects the state we are in. 
