### PR TITLE
adjusted service default timeout

### DIFF
--- a/config/totem.conf.example
+++ b/config/totem.conf.example
@@ -10,7 +10,7 @@ totem {
   }
 
   tasking_settings {
-    default_service_timeout = 60
+    default_service_timeout = 180
     prefetch = 3
     retry_attempts = 3
   }


### PR DESCRIPTION
objdump and gogadget do not always finish under 60 seconds
