### PR TITLE
Small naming fix

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/actors/WorkActor.scala
+++ b/src/main/scala/org/holmesprocessing/totem/actors/WorkActor.scala
@@ -94,7 +94,7 @@ class WorkActor(deliverytag: Long, filename: String, hashfilename: String, downl
     .setExecutorService(execServ)
     .setAllowPoolingConnections( downloadconfig.connection_pooling )
     .setConnectTimeout( downloadconfig.connect_timeout )
-    .setAcceptAnyCertificate( downloadconfig.validate_ssl_cert )
+    .setAcceptAnyCertificate( !downloadconfig.validate_ssl_cert )
     //.setMaxConnections(1)
     //.setMaxConnectionsPerHost(1)
     .setIOThreadMultiplier( downloadconfig.thread_multiplier ).build()


### PR DESCRIPTION
The config option is named "validate_ssl_cert" which implies:
true -> unvalid certs will be rejected
false -> unvalid certs will be accepted
But in the code we had `setAcceptAnyCertificate(validate_ssl_cert)` which needs to be `setAcceptAnyCertificate(!validate_ssl_cert)` to make sense.