### PR TITLE
Small Patch Collection

### DIFF
--- a/assembly.sbt
+++ b/assembly.sbt
@@ -1,14 +1,5 @@
-import AssemblyKeys._
-
-assemblySettings
-
-mergeStrategy in assembly <<= (mergeStrategy in assembly) { (old) =>
-  {
-    //case PathList("org", "apache", "commons-io", xs @ _*) => MergeStrategy.last
-    //case x => old(x)
-    case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
-    case m if m.toLowerCase.matches("meta-inf/.*\\.sf$") => MergeStrategy.discard
-    case "reference.conf" => MergeStrategy.concat
-    case _ => MergeStrategy.first //this was originally last, which worked up till client/server mismatch issues
-  }
+assemblyMergeStrategy in assembly := {
+	case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard   // not needed to keep these, discard
+	case "reference.conf" => MergeStrategy.concat                       // concat all akka reference.conf files 
+	case _ => MergeStrategy.first                                       // important to keep LICENSE files in place
 }

--- a/config/docker-compose.yml.example
+++ b/config/docker-compose.yml.example
@@ -160,10 +160,10 @@ services:
   pemeta:
     build:
       context: ../src/main/scala/org/holmesprocessing/totem/services/pemeta
-    args:
-      conf: ${CONFSTORAGE_PEMETA}service.conf
+      args:
+        conf: ${CONFSTORAGE_PEMETA}service.conf
     ports:
-      - "7810: 8080"
+      - "7810:8080"
     restart: unless-stopped
     volumes:
       - /tmp:/tmp:ro

--- a/config/docker-compose.yml.example
+++ b/config/docker-compose.yml.example
@@ -135,16 +135,16 @@ services:
     volumes:
      - /tmp:/tmp:ro
 
-  cfg:
-    build:
-      context: ../src/main/scala/org/holmesprocessing/totem/services/cfg
-      args:
-        conf: ${CONFSTORAGE_CFG}service.conf
-    ports:
-      - "7790:8080"
-    restart: unless-stopped
-    volumes:
-     - /tmp:/tmp:ro
+#  cfg:
+#    build:
+#      context: ../src/main/scala/org/holmesprocessing/totem/services/cfg
+#      args:
+#        conf: ${CONFSTORAGE_CFG}service.conf
+#    ports:
+#      - "7790:8080"
+#    restart: unless-stopped
+#    volumes:
+#     - /tmp:/tmp:ro
 
   cfgangr:
     build:
@@ -157,15 +157,13 @@ services:
     volumes:
      - /tmp:/tmp:ro
 
-  pemeta:
-    build:
-      context: ../src/main/scala/org/holmesprocessing/totem/services/pemeta
-      args:
-        conf: ${CONFSTORAGE_PEMETA}service.conf
-    ports:
-      - "7810:8080"
-    restart: unless-stopped
-    volumes:
-      - /tmp:/tmp:ro
-
-  
+#  pemeta:
+#    build:
+#      context: ../src/main/scala/org/holmesprocessing/totem/services/pemeta
+#      args:
+#        conf: ${CONFSTORAGE_PEMETA}service.conf
+#    ports:
+#      - "7810:8080"
+#    restart: unless-stopped
+#    volumes:
+#      - /tmp:/tmp:ro

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.10.2")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.2")
 
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.4.0")
-
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
+//No SBT 1.0 or 1.0.1 compatible version
+//addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")

--- a/src/main/scala/org/holmesprocessing/totem/actors/WorkActor.scala
+++ b/src/main/scala/org/holmesprocessing/totem/actors/WorkActor.scala
@@ -91,6 +91,7 @@ class WorkActor(deliverytag: Long, filename: String, hashfilename: String, downl
   val httpconfig = new AsyncHttpClientConfig.Builder()
     //TODO: set config for maxconnections
     .setRequestTimeout( downloadconfig.request_timeout )
+    .setReadTimeout( downloadconfig.request_timeout )
     .setExecutorService(execServ)
     .setAllowPoolingConnections( downloadconfig.connection_pooling )
     .setConnectTimeout( downloadconfig.connect_timeout )

--- a/src/main/scala/org/holmesprocessing/totem/services/passivetotal/src/passivetotal-service/main.go
+++ b/src/main/scala/org/holmesprocessing/totem/services/passivetotal/src/passivetotal-service/main.go
@@ -60,13 +60,18 @@ type Metadata struct {
 	License     string
 }
 type Settings struct {
-	Port           string
+	Port string
+}
+
+type PassivetotalSettings struct {
 	APIUser        string
 	APIKey         string
 	RequestTimeout int
 }
+
 type Config struct {
-	Setting Settings
+	Setting      Settings
+	Passivetotal PassivetotalSettings
 }
 
 // main logic
@@ -98,8 +103,8 @@ func main() {
 	router := httprouter.New()
 	router.GET("/analyze/", handlerAnalyze)
 	router.GET("/", handlerInfo)
-	infoLogger.Printf("Binding to %s\n", cfg.settings.port)
-	infoLogger.Fatal(http.ListenAndServe(cfg.settings.port, router))
+	infoLogger.Printf("Binding to %s\n", cfg.Setting.Port)
+	infoLogger.Fatal(http.ListenAndServe(cfg.Setting.Port, router))
 }
 
 func handlerInfo(f_response http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -156,9 +161,9 @@ func doPassiveTotalLookup(r *http.Request, p httprouter.Params) (interface{}, in
 	// via the request body into it (all options can be overriden):
 	aqs := &passivetotal.ApiQuerySettings{
 		Object:   obj,
-		Username: cfg.passivetotal.APIUser,
-		ApiKey:   cfg.passivetotal.APIKey,
-		Timeout:  cfg.passivetotal.RequestTimeout,
+		Username: cfg.Passivetotal.APIUser,
+		ApiKey:   cfg.Passivetotal.APIKey,
+		Timeout:  cfg.Passivetotal.RequestTimeout,
 	}
 
 	if r.Body != nil {

--- a/src/main/scala/org/holmesprocessing/totem/services/peid/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/peid/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /service
 ###
 
 # get dependencies
+RUN apk update && apk add ca-certificates wget && update-ca-certificates
 RUN apk add --no-cache \
 		autoconf \
 		automake \

--- a/src/main/scala/org/holmesprocessing/totem/services/yara/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/yara/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /service
 ###
 
 # get dependencies
+RUN apk update && apk add ca-certificates wget && update-ca-certificates
 RUN apk add --no-cache \
 		autoconf \
 		automake \


### PR DESCRIPTION
* Fixed syntax error in docker-compose.yml
* Added missing structs to config struct in passivetotal service
* Fixed incorrectly named struct fields in passivetotal service
* Fixed Dockerfile of peid not building
* Fixed Dockerfile of yara not building
* **NO** fix for cfg service not building: remote nucleus git only offers "master" instead of stable versions, does not compile at the moment
* **NO** fix for pemeta not building: missing files in remote git required by Go program (service author should take a look)
* Updated sbt to 1.0.1
* Updated sbt dependencies
* Cleaned up assembly.sbt
* Commented out not working services in docker-compose.yml
* Added `setReadTimeout` to really control totems timeout (was fixed at 60s, broke long running and resource intensive services)
