### PR TITLE
Update Dockerfile

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/services/cfgangr/Dockerfile
+++ b/src/main/scala/org/holmesprocessing/totem/services/cfgangr/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /service
 ###
 
 # add dependencies for cfgangr
-RUN pip2 install angr networkx
+RUN pip2 install angr networkx==1.11 simuvex
+RUN pip2 install -I --no-use-wheel capstone
 
 
 # add the files to the container

--- a/src/main/scala/org/holmesprocessing/totem/services/cfgangr/cfgangr.py
+++ b/src/main/scala/org/holmesprocessing/totem/services/cfgangr/cfgangr.py
@@ -32,9 +32,9 @@ Metadata = {
 }
 
 
-def CFGAngrRun(binary):
+def CFGAngrRun(binary, size):
     # Returns the CFG of a binary in JSON format
-    data = convertbinary.generateCFG(binary)
+    data = convertbinary.generateCFG(binary, size)
     return data
 
 
@@ -91,7 +91,7 @@ class CFGAngrApp(tornado.web.Application):
 
 def main():
     server = tornado.httpserver.HTTPServer(CFGAngrApp())
-    server.listen(Config["settings"]["httpbinding"])
+    server.listen(Config["settings"]["port"])
     try:
         tornado.ioloop.IOLoop.current().start()
     except KeyboardInterrupt:


### PR DESCRIPTION
Fix networkx version to 1.11 (latest before 2.0) to prevent inconsistencies with angr library. Otherwise, with networkx version 2.0, the following error will be generated by angr: "TypeError: object of type 'dictionary-keyiterator' has no len()". 
Reinstall capstone via pip install -I --no-use-wheel capstone to prevent "ImportError: cannot import name arm" error. The solution was suggested in the issues of angr library: https://github.com/angr/angr/issues/52