### PR TITLE
Disable Armadillo v1.71 PEiD rule

### DIFF
--- a/src/main/scala/org/holmesprocessing/totem/services/peid/rulepack/peid-userdb-rules-with-pe-module.yar
+++ b/src/main/scala/org/holmesprocessing/totem/services/peid/rulepack/peid-userdb-rules-with-pe-module.yar
@@ -1519,7 +1519,8 @@ rule PEiD_00137_Armadillo_v1_60a_
         $a at pe.entry_point
 }
 
-rule PEiD_00138_Armadillo_v1_71_
+// This signature is a false positive
+/*rule PEiD_00138_Armadillo_v1_71_
 {
     meta:
         description = "[Armadillo v1.71]"
@@ -1528,7 +1529,7 @@ rule PEiD_00138_Armadillo_v1_71_
         $a = {55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1}
     condition:
         $a
-}
+}*/
 
 rule PEiD_00139_Armadillo_v1_72___v1_73_
 {


### PR DESCRIPTION
PEiD signature is a false positive that detects MSVC compiled binaries.

Only disabled in the rule that is enabled in rules.yar